### PR TITLE
Property test for vector bounds.

### DIFF
--- a/succinct-vector.cabal
+++ b/succinct-vector.cabal
@@ -43,7 +43,8 @@ Test-Suite tests
         base       >= 4      && < 5   ,
         doctest    >= 0.9.12 && < 0.11,
         QuickCheck >= 2.8    && < 2.9 ,
-        succinct-vector
+        succinct-vector               ,
+        vector
 
 Benchmark bench
     Type: exitcode-stdio-1.0

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE FlexibleInstances #-}
-
 module Main where
 
 import Data.Word (Word64)
@@ -67,15 +65,16 @@ bitVectorR = testR
 
 data VectorRank = VectorRank [Word64] Position deriving (Eq, Show)
 
-data LenAsPos a = LenAsPos a deriving (Eq, Show)
+data LenAsPos = LenAsPos VectorRank deriving (Eq, Show)
 
-instance Arbitrary (LenAsPos VectorRank) where
+instance Arbitrary LenAsPos where
   arbitrary = do
     h <- arbitrary :: Gen Word64
     v <- arbitrary :: Gen [Word64]
     let n = (length v + 1) * 64 :: Int
     return (LenAsPos (VectorRank (h:v) (Position n)))
 
+workingLenPos :: Property
 workingLenPos = property $
     \(LenAsPos (VectorRank as i)) ->
       let nv = prepare (DV.fromList as :: DV.Vector Word64) in


### PR DESCRIPTION
Added a property test that fails catastrophically do to an index out of bounds access.

```
$ stack test
+++ OK, passed 100 tests.
+++ OK, passed 100 tests.
+++ OK, passed 100 tests.
+++ OK, passed 100 tests.
+++ OK, passed 100 tests.
+++ OK, passed 100 tests.
+++ OK, passed 100 tests.
+++ OK, passed 100 tests.

Completed 2 action(s).
Test suite failure for package succinct-vector-1.0.0
    tests:  exited with: ExitFailure (-11)
Logs printed to console
```